### PR TITLE
fix: Fix incompatibiliy with MySQL v5.7

### DIFF
--- a/src/Migrations/Version20200510171200.php
+++ b/src/Migrations/Version20200510171200.php
@@ -22,7 +22,7 @@ final class Version20200510171200 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE company  CHANGE COLUMN `postal_code` `postal_code` VARCHAR(255) NULL DEFAULT NULL ');
-        $this->addSql('ALTER TABLE company  ADD UNIQUE INDEX `name_UNIQUE` (`name` ASC) VISIBLE; ');
+        $this->addSql('ALTER TABLE company  ADD UNIQUE INDEX `name_UNIQUE` (`name` ASC)');
     }
 
     public function down(Schema $schema) : void


### PR DESCRIPTION
The keyword 'VISIBILE' is not available in MySQL 5.7

This script was auto generated with help from MySQL Workbench,  To get the correct request I have reconfigured it to create requests for version 5.7