### PR TITLE
fix: Add timestamp to prevent null time values

### DIFF
--- a/src/Entity/Admin/User.php
+++ b/src/Entity/Admin/User.php
@@ -76,6 +76,9 @@ class User implements UserInterface
     public function __construct()
     {
         $this->companies = new ArrayCollection();
+
+        $this->createdAt = time();
+        $this->updatedAt = time();
     }
 
     public function getId(): ?int

--- a/src/Entity/Company.php
+++ b/src/Entity/Company.php
@@ -118,6 +118,12 @@ class Company
      */
     private $updatedAt;
 
+    public function __construct()
+    {
+        $this->createdAt = time();
+        $this->updatedAt = time();
+    }
+
     public function getId(): ?int
     {
         return $this->id;


### PR DESCRIPTION
These values should be set to sensible defaults, otherwise we can have unintended bugs elsewhere,
for example the creation of doctrine fixtures :

![image](https://user-images.githubusercontent.com/4537119/82441446-356bf800-9a9e-11ea-8bc3-b63ec6fd3998.png)

